### PR TITLE
Add Kali MCP server implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# simflood
+# Kali MCP Server
+
+This repository provides a ready-to-run [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server that exposes a curated, safe subset of popular Kali Linux tooling. It is designed to let AI agents run common discovery and reconnaissance utilities without granting unrestricted shell access.
+
+## Features
+
+- Allow-listed wrappers around widely used Kali utilities such as `nmap`, `sqlmap`, `gobuster`, `curl`, `ssh`, and more.
+- Strict argument validation with per-command timeouts to reduce the risk of destructive execution or accidental long-running scans.
+- Rich metadata describing each command, including default arguments, accepted flags, and example invocations.
+- A Markdown reference resource (`resource://kali/commands`) that can be rendered directly by MCP-aware clients.
+- Multiple transport options (stdio, SSE, or streamable HTTP) exposed through a simple command line interface.
+
+## Getting Started
+
+1. Install the project dependencies (Python 3.11+ is recommended):
+
+   ```bash
+   pip install -e .
+   ```
+
+2. Launch the server using the desired transport. For example, to run over stdio (ideal when embedding inside an MCP-compatible agent):
+
+   ```bash
+   python -m kali_mcp_server
+   ```
+
+   Or to expose the SSE transport on port 8000:
+
+   ```bash
+   python -m kali_mcp_server --transport sse --host 0.0.0.0 --port 8000
+   ```
+
+## MCP Tools
+
+The server registers three primary MCP tools:
+
+- `list_commands` — returns metadata for every allow-listed command. Pass `only_installed=true` to filter the list to binaries present on the host.
+- `describe_command` — inspects a single command by name and returns its documentation, allowed flags, timeouts, and installation status.
+- `run_command` — executes a command with validated arguments. Use the optional `dry_run=true` flag to preview the normalised invocation without launching the process.
+
+A rendered Markdown overview is also available via the `resource://kali/commands` resource.
+
+> **Note:** The execution environment used by this repository may not include the full Kali toolchain. Always consult the `installed` attribute returned by `list_commands`/`describe_command` before attempting to run a command.
+
+## Development
+
+Run a quick sanity check to ensure the code compiles:
+
+```bash
+python -m compileall kali_mcp_server
+```
+
+Contributions are welcome via pull requests.

--- a/kali_mcp_server/__init__.py
+++ b/kali_mcp_server/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for creating the Kali MCP server."""
+
+from .server import create_server
+
+__all__ = ["create_server"]

--- a/kali_mcp_server/__main__.py
+++ b/kali_mcp_server/__main__.py
@@ -1,0 +1,56 @@
+"""Command line entry point for the Kali MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Iterable
+
+from .server import create_server
+
+
+async def _run(transport: str, *, host: str, port: int, mount_path: str) -> None:
+    server = create_server(host=host, port=port)
+
+    if transport == "stdio":
+        await server.run_stdio_async()
+    elif transport == "sse":
+        await server.run_sse_async(mount_path=mount_path)
+    elif transport == "http":
+        await server.run_streamable_http_async()
+    else:
+        raise ValueError(f"Unsupported transport '{transport}'.")
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the Kali MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "http"),
+        default="stdio",
+        help="Transport to expose (default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host/interface for SSE or HTTP transports (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for SSE or HTTP transports (default: 8000)",
+    )
+    parser.add_argument(
+        "--mount-path",
+        default="/",
+        help="URL mount path when using the SSE transport (default: /)",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    asyncio.run(_run(args.transport, host=args.host, port=args.port, mount_path=args.mount_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/kali_mcp_server/commands.py
+++ b/kali_mcp_server/commands.py
@@ -1,0 +1,473 @@
+"""Allow-listed command specifications for the Kali MCP server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+import shutil
+from typing import Iterable, Sequence
+
+_ALLOWED_VALUE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.:,/@?=&%+*-{}[]\"'~"
+_SAFE_VALUE_PATTERN = re.compile(rf"^[{re.escape(_ALLOWED_VALUE_CHARS)}]+$")
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Metadata describing how a command may be executed safely."""
+
+    name: str
+    binary: str
+    description: str
+    default_args: tuple[str, ...] = field(default_factory=tuple)
+    allowed_flags: frozenset[str] = field(default_factory=frozenset)
+    allowed_flag_prefixes: tuple[str, ...] = field(default_factory=tuple)
+    allow_positional: bool = True
+    example: str | None = None
+    notes: str | None = None
+    timeout: float = 300.0
+    max_arguments: int = 16
+
+    def normalize_arguments(self, user_arguments: Sequence[str] | None) -> list[str]:
+        """Validate and normalise arguments according to the specification."""
+
+        arguments: list[str] = list(self.default_args)
+        if not user_arguments:
+            return arguments
+
+        if len(user_arguments) > self.max_arguments:
+            raise ValueError(
+                f"Too many arguments provided for {self.name}. Limit is {self.max_arguments}."
+            )
+
+        for raw_arg in user_arguments:
+            arg = raw_arg.strip()
+            if not arg:
+                raise ValueError("Empty arguments are not permitted.")
+
+            if arg.startswith("-"):
+                if arg in self.allowed_flags or any(
+                    arg.startswith(prefix) for prefix in self.allowed_flag_prefixes
+                ):
+                    arguments.append(arg)
+                    continue
+                raise ValueError(
+                    f"Flag '{arg}' is not in the allow list for {self.name}."
+                )
+
+            if not self.allow_positional:
+                raise ValueError(
+                    f"Positional arguments are disabled for {self.name}; please use explicit flags."
+                )
+
+            if not _SAFE_VALUE_PATTERN.match(arg):
+                raise ValueError(
+                    "Only alphanumeric characters and _ . : , / @ ? = % + * - are allowed in positional values."
+                )
+
+            arguments.append(arg)
+
+        return arguments
+
+    def is_installed(self) -> bool:
+        """Return True when the binary exists in PATH."""
+
+        return shutil.which(self.binary) is not None
+
+
+def _flags(*items: str) -> frozenset[str]:
+    return frozenset(items)
+
+
+def _prefixes(*items: str) -> tuple[str, ...]:
+    return tuple(items)
+
+
+COMMANDS: dict[str, CommandSpec] = {
+    spec.name: spec
+    for spec in [
+        CommandSpec(
+            name="nmap",
+            binary="nmap",
+            description="Network mapper for discovery, port scanning and service detection.",
+            default_args=("-Pn",),
+            allowed_flags=_flags(
+                "-sV",
+                "-sS",
+                "-O",
+                "-A",
+                "-Pn",
+                "-vv",
+                "-vvv",
+                "-n",
+                "-6",
+                "--open",
+                "--reason",
+                "--traceroute",
+                "--disable-arp-ping",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-p",
+                "-T",
+                "--top-ports",
+                "-o",
+                "--script",
+                "--max-retries",
+                "--min-rate",
+                "--max-rate",
+            ),
+            example="nmap -sV -p 80,443 example.com",
+            notes="Large scans may take a long time; consider limiting the port range.",
+            timeout=420.0,
+        ),
+        CommandSpec(
+            name="sqlmap",
+            binary="sqlmap",
+            description="Automated SQL injection detection and exploitation framework.",
+            allowed_flags=_flags(
+                "--batch",
+                "--random-agent",
+                "--flush-session",
+                "--threads",
+                "--tor",
+                "--tor-type",
+                "--risk",
+                "--level",
+                "--forms",
+                "-v",
+                "-o",
+                "-r",
+                "-c",
+                "-p",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-u",
+                "--risk",
+                "--level",
+                "--technique",
+                "--tamper",
+                "--threads",
+                "--time-sec",
+                "--delay",
+                "--timeout",
+            ),
+            example="sqlmap -u https://example.com/page.php?id=1 --batch",
+            notes="sqlmap can generate significant traffic; ensure you have permission before scanning.",
+            timeout=600.0,
+        ),
+        CommandSpec(
+            name="subfinder",
+            binary="subfinder",
+            description="Passive subdomain discovery utility.",
+            allowed_flags=_flags(
+                "-silent",
+                "-all",
+                "-recursive",
+                "-nc",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-d",
+                "-dL",
+                "-o",
+                "-oJ",
+                "-oD",
+                "-t",
+            ),
+            example="subfinder -d example.com -silent",
+        ),
+        CommandSpec(
+            name="nikto",
+            binary="nikto",
+            description="Web server vulnerability scanner.",
+            allowed_flags=_flags(
+                "-ssl",
+                "-useproxy",
+                "-Plugins",
+                "-Tuning",
+                "-no404",
+                "-mutate",
+                "-Display",
+                "-Cgidirs",
+                "-maxtime",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-h",
+                "-p",
+                "-o",
+                "-Format",
+                "-Tuning",
+                "-timeout",
+            ),
+            example="nikto -h https://example.com -ssl",
+        ),
+        CommandSpec(
+            name="gobuster",
+            binary="gobuster",
+            description="Directory, DNS and VHost brute forcing utility.",
+            allowed_flags=_flags(
+                "-k",
+                "-r",
+                "-fw",
+                "-fa",
+                "-q",
+                "-v",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "dir",
+                "dns",
+                "vhost",
+                "fuzz",
+                "-u",
+                "-w",
+                "-t",
+                "-p",
+                "-o",
+                "-s",
+                "-x",
+                "-b",
+            ),
+            example="gobuster dir -u https://example.com -w /path/to/wordlist.txt",
+            notes="Specify the mode as the first argument (dir/dns/vhost/fuzz).",
+        ),
+        CommandSpec(
+            name="theharvester",
+            binary="theHarvester",
+            description="Information gathering tool for emails, domains and hosts.",
+            allowed_flags=_flags(
+                "-v",
+                "-f",
+                "-n",
+                "-c",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-d",
+                "-l",
+                "-b",
+                "-h",
+                "-s",
+                "-g",
+                "-p",
+            ),
+            example="theHarvester -d example.com -b bing",
+        ),
+        CommandSpec(
+            name="tshark",
+            binary="tshark",
+            description="Terminal network protocol analyser from the Wireshark suite.",
+            allowed_flags=_flags(
+                "-V",
+                "-r",
+                "-l",
+                "-t",
+                "-q",
+                "-O",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-i",
+                "-f",
+                "-Y",
+                "-T",
+                "-o",
+            ),
+            example="tshark -i eth0 -Y http",
+            notes="Capturing may require elevated permissions; ensure you comply with local policies.",
+        ),
+        CommandSpec(
+            name="john",
+            binary="john",
+            description="John the Ripper password cracking utility.",
+            allowed_flags=_flags(
+                "--show",
+                "--test",
+                "--wordlist",
+                "--rules",
+                "--incremental",
+                "--format",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "--wordlist",
+                "--rules",
+                "--format",
+                "--session",
+                "--restore",
+            ),
+            example="john --wordlist=/path/to/wordlist.txt hashes.txt",
+            notes="Be mindful of resource consumption when running intensive cracking jobs.",
+            timeout=900.0,
+        ),
+        CommandSpec(
+            name="tcpdump",
+            binary="tcpdump",
+            description="Packet capture tool for network troubleshooting and analysis.",
+            allowed_flags=_flags(
+                "-n",
+                "-nn",
+                "-e",
+                "-q",
+                "-v",
+                "-vv",
+                "-vvv",
+                "-X",
+                "-XX",
+                "-w",
+                "-r",
+                "-tt",
+                "-tttt",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-i",
+                "-s",
+                "-c",
+                "-G",
+                "-W",
+                "-C",
+                "-F",
+                "-E",
+                "-Z",
+            ),
+            example="tcpdump -i eth0 -c 100 port 443",
+            notes="Requires capture privileges; output can grow quickly so consider limiting packet count.",
+        ),
+        CommandSpec(
+            name="curl",
+            binary="curl",
+            description="Command line transfer tool supporting numerous protocols.",
+            allowed_flags=_flags(
+                "-I",
+                "-L",
+                "-k",
+                "-v",
+                "-s",
+                "-S",
+                "-o",
+                "-O",
+                "-X",
+                "-u",
+                "--data",
+                "--data-binary",
+                "--data-urlencode",
+                "--header",
+                "--head",
+                "--compressed",
+                "--resolve",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "http://",
+                "https://",
+                "ftp://",
+                "--url",
+                "--user",
+                "--proxy",
+                "--max-time",
+                "--connect-timeout",
+            ),
+            example="curl -I https://example.com",
+            notes="Use --data/--data-binary to submit payloads explicitly; positional values are treated as URLs.",
+            timeout=180.0,
+        ),
+        CommandSpec(
+            name="wget",
+            binary="wget",
+            description="Non-interactive network downloader.",
+            allowed_flags=_flags(
+                "-q",
+                "-v",
+                "-O",
+                "-o",
+                "-c",
+                "-r",
+                "-np",
+                "-nH",
+                "--cut-dirs",
+                "--limit-rate",
+                "--user",
+                "--password",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "http://",
+                "https://",
+                "ftp://",
+                "--user",
+                "--password",
+                "--limit-rate",
+                "--reject",
+                "--accept",
+            ),
+            example="wget https://example.com/index.html",
+        ),
+        CommandSpec(
+            name="ssh",
+            binary="ssh",
+            description="OpenSSH secure remote login client.",
+            allowed_flags=_flags(
+                "-i",
+                "-p",
+                "-v",
+                "-vv",
+                "-vvv",
+                "-o",
+                "-J",
+                "-L",
+                "-R",
+                "-D",
+                "-N",
+                "-T",
+                "-f",
+                "-F",
+                "-4",
+                "-6",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-p",
+                "-i",
+                "-o",
+                "-L",
+                "-R",
+                "-D",
+                "-J",
+            ),
+            example="ssh -p 2222 user@example.com",
+            notes="Interactive sessions will stream until the command completes; consider using -N for port forwarding only.",
+            timeout=600.0,
+        ),
+        CommandSpec(
+            name="searchsploit",
+            binary="searchsploit",
+            description="Exploit Database command line search utility.",
+            allowed_flags=_flags(
+                "-m",
+                "-x",
+                "-v",
+                "-j",
+                "-u",
+                "-p",
+                "-w",
+                "-t",
+                "-s",
+            ),
+            allowed_flag_prefixes=_prefixes(
+                "-c",
+                "-e",
+                "-p",
+            ),
+            example="searchsploit -t wordpress",
+        ),
+    ]
+}
+
+
+def get_command(name: str) -> CommandSpec:
+    """Retrieve a command specification by name, raising KeyError when missing."""
+
+    key = name.strip().lower()
+    if key not in COMMANDS:
+        raise KeyError(f"Unknown command '{name}'.")
+    return COMMANDS[key]
+
+
+def iter_commands() -> Iterable[CommandSpec]:
+    """Return an iterable of all available command specifications."""
+
+    return COMMANDS.values()
+
+
+__all__ = ["CommandSpec", "COMMANDS", "get_command", "iter_commands"]

--- a/kali_mcp_server/models.py
+++ b/kali_mcp_server/models.py
@@ -1,0 +1,43 @@
+"""Pydantic models used by the Kali MCP server."""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CommandInfo(BaseModel):
+    """Metadata describing an allowed command."""
+
+    name: str = Field(..., description="Human friendly command identifier")
+    binary: str = Field(..., description="Executable name invoked on the system")
+    description: str = Field(..., description="Short explanation of the command purpose")
+    default_args: list[str] = Field(default_factory=list, description="Arguments applied automatically")
+    allowed_flags: list[str] = Field(default_factory=list, description="Safe flags that may be provided verbatim")
+    allowed_flag_prefixes: list[str] = Field(
+        default_factory=list,
+        description="Flag prefixes that enable parameterised arguments (e.g. -p80)",
+    )
+    installed: bool = Field(..., description="Whether the executable was found in $PATH at runtime")
+    example: Optional[str] = Field(None, description="Example invocation for quick reference")
+    notes: Optional[str] = Field(None, description="Additional hints or caveats for the command")
+
+
+class CommandExecutionResult(BaseModel):
+    """Normalised output from executing an allow-listed command."""
+
+    command: str = Field(..., description="Logical command identifier")
+    binary: str = Field(..., description="Concrete binary executed")
+    arguments: list[str] = Field(default_factory=list, description="Arguments passed to the binary")
+    status: Literal["success", "error", "missing", "timeout"] = Field(
+        ..., description="Final outcome of the execution request"
+    )
+    returncode: Optional[int] = Field(None, description="Process return code when available")
+    stdout: str = Field("", description="Captured standard output (truncated if necessary)")
+    stderr: str = Field("", description="Captured standard error (truncated if necessary)")
+    duration_ms: float = Field(..., description="Execution duration in milliseconds")
+    message: Optional[str] = Field(None, description="Human readable message describing the outcome")
+
+
+__all__ = ["CommandInfo", "CommandExecutionResult"]

--- a/kali_mcp_server/server.py
+++ b/kali_mcp_server/server.py
@@ -1,0 +1,273 @@
+"""Factory for the Kali MCP server."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import shutil
+import textwrap
+import time
+from typing import Iterable, Sequence
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from .commands import CommandSpec, get_command, iter_commands
+from .models import CommandExecutionResult, CommandInfo
+
+_MAX_CAPTURE_BYTES = 65_536
+
+
+def _truncate_output(raw: bytes, *, limit: int = _MAX_CAPTURE_BYTES) -> str:
+    """Convert captured process output to a bounded UTF-8 string."""
+
+    text = raw.decode("utf-8", errors="replace")
+    if len(text) <= limit:
+        return text
+    truncated = text[:limit]
+    omitted = len(text) - limit
+    return f"{truncated}\n...[truncated {omitted} characters]"
+
+
+def _spec_to_info(spec: CommandSpec) -> CommandInfo:
+    return CommandInfo(
+        name=spec.name,
+        binary=spec.binary,
+        description=spec.description,
+        default_args=list(spec.default_args),
+        allowed_flags=sorted(spec.allowed_flags),
+        allowed_flag_prefixes=list(spec.allowed_flag_prefixes),
+        installed=spec.is_installed(),
+        example=spec.example,
+        notes=spec.notes,
+    )
+
+
+async def _execute_command(
+    spec: CommandSpec,
+    arguments: Sequence[str],
+    *,
+    context: Context | None,
+    dry_run: bool,
+) -> CommandExecutionResult:
+    """Execute a command according to its specification."""
+
+    binary_path = shutil.which(spec.binary)
+    if binary_path is None:
+        if context is not None:
+            await context.warning(
+                f"Binary '{spec.binary}' was not found in PATH. Returning a synthetic result."
+            )
+            await context.report_progress(100, 100)
+        return CommandExecutionResult(
+            command=spec.name,
+            binary=spec.binary,
+            arguments=list(arguments),
+            status="missing",
+            returncode=None,
+            stdout="",
+            stderr="",
+            duration_ms=0.0,
+            message="Executable not installed on this system.",
+        )
+
+    if dry_run:
+        if context is not None:
+            await context.info(
+                "Dry run requested; returning the normalised command without executing it."
+            )
+            await context.report_progress(100, 100)
+        return CommandExecutionResult(
+            command=spec.name,
+            binary=binary_path,
+            arguments=list(arguments),
+            status="success",
+            returncode=None,
+            stdout="",
+            stderr="",
+            duration_ms=0.0,
+            message="Dry run only; no process was started.",
+        )
+
+    start = time.perf_counter()
+    if context is not None:
+        await context.report_progress(5, 100)
+        await context.info(
+            f"Launching {spec.binary} with arguments: {' '.join(arguments) or '<none>'}"
+        )
+
+    process = await asyncio.create_subprocess_exec(
+        binary_path,
+        *arguments,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            process.communicate(), timeout=spec.timeout
+        )
+    except asyncio.TimeoutError:
+        process.kill()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(process.communicate(), timeout=5)
+        duration = (time.perf_counter() - start) * 1000
+        if context is not None:
+            await context.error(
+                f"{spec.name} exceeded the configured timeout of {spec.timeout:.0f} seconds."
+            )
+            await context.report_progress(100, 100)
+        return CommandExecutionResult(
+            command=spec.name,
+            binary=binary_path,
+            arguments=list(arguments),
+            status="timeout",
+            returncode=None,
+            stdout="",
+            stderr="",
+            duration_ms=duration,
+            message=f"Command timed out after {spec.timeout:.0f} seconds.",
+        )
+
+    duration = (time.perf_counter() - start) * 1000
+    stdout = _truncate_output(stdout_bytes)
+    stderr = _truncate_output(stderr_bytes)
+    status = "success" if process.returncode == 0 else "error"
+    message = None if status == "success" else f"Process exited with code {process.returncode}."
+
+    if context is not None:
+        await context.report_progress(100, 100)
+        if status == "success":
+            await context.info(f"{spec.name} completed successfully in {duration:.0f} ms.")
+        else:
+            await context.error(message or "Command reported an error.")
+
+    return CommandExecutionResult(
+        command=spec.name,
+        binary=binary_path,
+        arguments=list(arguments),
+        status=status,
+        returncode=process.returncode,
+        stdout=stdout,
+        stderr=stderr,
+        duration_ms=duration,
+        message=message,
+    )
+
+
+def _render_reference(specs: Iterable[CommandSpec]) -> str:
+    """Render a Markdown reference document describing all commands."""
+
+    lines: list[str] = ["# Kali MCP Command Reference", ""]
+    for spec in sorted(specs, key=lambda item: item.name):
+        lines.append(f"## {spec.name}")
+        lines.append("")
+        lines.append(spec.description)
+        lines.append("")
+        lines.append(f"* Binary: `{spec.binary}`")
+        if spec.default_args:
+            lines.append(f"* Default arguments: {' '.join(spec.default_args)}")
+        if spec.allowed_flags:
+            flags = "`, `".join(sorted(spec.allowed_flags))
+            lines.append(f"* Allowed flags: `{flags}`")
+        if spec.allowed_flag_prefixes:
+            prefixes = "`, `".join(spec.allowed_flag_prefixes)
+            lines.append(f"* Allowed flag prefixes: `{prefixes}`")
+        lines.append(f"* Timeout: {spec.timeout:.0f} seconds")
+        if spec.example:
+            lines.append(f"* Example: `{spec.example}`")
+        if spec.notes:
+            lines.append(f"* Notes: {spec.notes}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+_INSTRUCTIONS = textwrap.dedent(
+    """
+    This server exposes safe wrappers around popular Kali Linux tooling.
+
+    * Use `list_commands` to enumerate the allow-listed utilities and check which
+      binaries are available on the current host.
+    * `describe_command` returns detailed metadata about a specific tool, including
+      allowed flags and timeouts.
+    * `run_command` executes a tool with validated arguments. Only documented flags
+      and prefix forms are accepted, and positional arguments are sanitised to avoid
+      shell injection. Many heavy-weight tools may not be installed in the runtime
+      environment; always inspect `installed` before execution.
+    * Set the optional `dry_run` parameter when you only need the normalised
+      invocation without actually launching the command.
+    """
+).strip()
+
+
+def create_server(*, host: str = "127.0.0.1", port: int = 8000) -> FastMCP:
+    """Create and configure the Kali MCP server instance."""
+
+    server = FastMCP(
+        name="kali-mcp-server",
+        instructions=_INSTRUCTIONS,
+        host=host,
+        port=port,
+    )
+
+    @server.resource(
+        "resource://kali/commands",
+        name="kali-commands",
+        title="Kali MCP command reference",
+        description="Markdown reference describing the allow-listed Kali commands.",
+        mime_type="text/markdown",
+    )
+    def command_reference() -> str:
+        return _render_reference(iter_commands())
+
+    @server.tool(
+        name="list_commands",
+        description="Return metadata for all allow-listed commands.",
+        structured_output=True,
+    )
+    def list_commands(only_installed: bool = False) -> list[CommandInfo]:
+        specs = list(iter_commands())
+        if only_installed:
+            specs = [spec for spec in specs if spec.is_installed()]
+        return [_spec_to_info(spec) for spec in sorted(specs, key=lambda item: item.name)]
+
+    @server.tool(
+        name="describe_command",
+        description="Return metadata for a single allow-listed command.",
+        structured_output=True,
+    )
+    def describe_command(command: str) -> CommandInfo:
+        try:
+            spec = get_command(command)
+        except KeyError as exc:
+            raise ValueError(str(exc)) from exc
+        return _spec_to_info(spec)
+
+    @server.tool(
+        name="run_command",
+        description="Execute an allow-listed Kali command with validated arguments.",
+        structured_output=True,
+    )
+    async def run_command(
+        command: str,
+        arguments: Sequence[str] | None = None,
+        dry_run: bool = False,
+        context: Context | None = None,
+    ) -> CommandExecutionResult:
+        try:
+            spec = get_command(command)
+        except KeyError as exc:
+            raise ValueError(str(exc)) from exc
+
+        try:
+            normalised_args = spec.normalize_arguments(arguments or [])
+        except ValueError as exc:
+            if context is not None:
+                await context.error(str(exc))
+            raise
+
+        return await _execute_command(spec, normalised_args, context=context, dry_run=dry_run)
+
+    return server
+
+
+__all__ = ["create_server"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kali-mcp-server"
+version = "0.1.0"
+description = "Model Context Protocol server exposing a safe subset of Kali Linux tooling"
+readme = "README.md"
+authors = [
+  {name = "OpenAI Simulated Agent"}
+]
+requires-python = ">=3.11"
+dependencies = [
+  "mcp>=1.15.0",
+  "pydantic>=2.8",
+]
+
+[project.scripts]
+kali-mcp-server = "kali_mcp_server.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["kali_mcp_server"]


### PR DESCRIPTION
## Summary
- implement a FastMCP-based Kali server with instructions, resources, and MCP tool registrations
- define an allow-list of Kali utilities with argument validation, metadata models, and structured execution responses
- document project usage and package metadata for easy installation

## Testing
- python -m compileall kali_mcp_server
- python - <<'PY'
import asyncio
from kali_mcp_server import create_server

async def main():
    server = create_server()
    tools = await server.list_tools()
    for tool in tools:
        print(tool.name)

asyncio.run(main())
PY


------
https://chatgpt.com/codex/tasks/task_b_68d8305568f8832786cc480c4750a41e